### PR TITLE
Add hyperlink to separate A2B Design History

### DIFF
--- a/app/posts/conversions/conversions.md
+++ b/app/posts/conversions/conversions.md
@@ -3,11 +3,12 @@ tags: false
 layout: collection
 title: Academy Conversions
 description: An internal service for DfE colleagues to manage applications from schools applying to become academies.
-permalink: "conversions/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% endif %}/"
 eleventyComputed:
   eleventyNavigation:
     key: "{{ title }}"
     excerpt: "{{ description }}"
+    url: "https://conversions-design-history.netlify.app/apply-to-become-academy/"
+    permalink: false
     parent: home
 ---
 


### PR DESCRIPTION
A new hyperlink has been added to direct users from the shared SDD Design History to the separate A2B Design History