### PR TITLE
Fix post AB not showing up

### DIFF
--- a/app/_layouts/collection.njk
+++ b/app/_layouts/collection.njk
@@ -80,6 +80,7 @@
               <p class="govuk-body">{{ item.excerpt }}</p>
             </section>      
           {% endfor %}
+          
           <div class="govuk-grid-column-full">
             <h2 class="govuk-heading-l govuk-!-font-size-27">
               Reference

--- a/app/posts/post-advisory-board/2021-10-20-part-1-post-ab.md
+++ b/app/posts/post-advisory-board/2021-10-20-part-1-post-ab.md
@@ -1,0 +1,8 @@
+---
+title: Starting post AB transfers and conversions
+description:
+date: 2021-10-20
+---
+
+Hello World!
+

--- a/app/posts/post-advisory-board/2021-10-21-part-2-post.md
+++ b/app/posts/post-advisory-board/2021-10-21-part-2-post.md
@@ -1,0 +1,8 @@
+---
+title: Post AB (part 2)
+description:
+date: 2021-10-21
+---
+
+Hello World!
+

--- a/app/posts/post-advisory-board/post-advisory-board.json
+++ b/app/posts/post-advisory-board/post-advisory-board.json
@@ -1,8 +1,8 @@
 {
   "tags": [
-    "post-ab"
+    "post-advisory-board"
   ],
   "eleventyNavigation": {
-    "parent": "Post-advisory board (AT and A2B)"
+    "parent": "Post advisory board"
   }
 }

--- a/app/posts/post-advisory-board/post-advisory-board.md
+++ b/app/posts/post-advisory-board/post-advisory-board.md
@@ -1,12 +1,12 @@
 ---
 tags: posts
-layout: collection
-title: Post-advisory board (AT and A2B)
-description: A service to help trusts understand what changes they need to make an application for, and for SDD Delivery Officers to manage those applications.
-pagination:
-  data: collections.post-advisory-board
-  reverse: true
-  size: 25
+layout: page
+title: Post advisory board
+description: A service to help trusts understand what changes they need to make an application for, and for SDD Delivery Officers to manage those applications
+# pagination:
+#   data: collections.post-advisory-board
+#   reverse: true
+#   size: 50
 permalink: "post-advisory-board/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% endif %}/"
 eleventyComputed:
   eleventyNavigation:
@@ -15,3 +15,12 @@ eleventyComputed:
     parent: home
     order: 5
 ---
+
+## How we conduted the discovery work for post-advisory board from AT and A2B landscape
+
+Post-advisory board work is split into two parts:
+
+* part 1 focusses on synthesising the existing research to create as is user journeys and identifying the pain points from delivery leads
+* part 2 focusses on understanding the busness needs from teams within RDD
+
+### [Starting post AB transfers and conversions – Part 1](part-1-post-ab/)

--- a/app/posts/posts.json
+++ b/app/posts/posts.json
@@ -1,7 +1,7 @@
 {
   "layout": "post",
   "permalink": "{{ page.filePathStem | replace('posts/', '') }}/",
-  "tags": ["posts"],
+  "tags": ["search-index"],
   "eleventyComputed": {
     "eleventyNavigation": {
       "key": "{{ title }}",


### PR DESCRIPTION
- used a work around to display post ab within the homepage
- we have to use layout as a page and link of the relevant posts within post ab under /post-advisory-board page