### PR TITLE
removed link to concerns design history

### DIFF
--- a/app/posts/concerns/concerns.md
+++ b/app/posts/concerns/concerns.md
@@ -1,14 +1,9 @@
 ---
 tags: posts
-layout: collection
 title: Concerns Casework
 description: An internal service for AMSD caseworkers to manage trusts and academies with financial, governance, and safeguarding concerns.
-eleventyComputed:
-  eleventyNavigation:
-    key: "{{ title }}"
-    excerpt: "{{ description }}"
-    url: "https://concerns-casework-design-history.netlify.app/"
-    permalink: false
-    parent: home
-    order: 1
 ---
+## Gaining access
+
+The Concerns Casework project design history can only be accessed by those working on SDD digital projects. Please contact the team's Product Owner if you require access.
+ 


### PR DESCRIPTION
Much of the work done for Concerns project is required to be for a limited audience. As such it needs to be unlinked from the main SDD design history site.